### PR TITLE
Fix brevitas name in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scipy>=1.4.1
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.41.0
-breavitas>=0.7.1
+brevitas>=0.7.1
 
 # Logging -------------------------------------
 tensorboard>=2.4.1


### PR DESCRIPTION
There was a typo on the brevitas requirements, that was misspelt. I fix it and now it should be correct!